### PR TITLE
New language translators

### DIFF
--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -268,6 +268,7 @@ class MatlabTranslator(Translator):
 # Instantiate a PapermillIO instance and register Handlers.
 papermill_translators = PapermillTranslators()
 papermill_translators.register("python", PythonTranslator)
+papermill_translators.register("sos", PythonTranslator)
 papermill_translators.register("R", RTranslator)
 papermill_translators.register("scala", ScalaTranslator)
 papermill_translators.register("julia", JuliaTranslator)


### PR DESCRIPTION
Adds support for:
- Octave (reuse Matlab translator)
- SoS (reuse Python translator; only picks up parameters in Python-compatible subkernel cells: Python and SoS)

TODO:
- Java
- Full SoS support (read parameters from any supported language subkernel cell)